### PR TITLE
Add argument to skip filtering if so desired.

### DIFF
--- a/babel/sc_data_loaders.py
+++ b/babel/sc_data_loaders.py
@@ -189,30 +189,6 @@ TENX_PBMC_RNA_DATA_KWARGS = {
     "cluster_res": 1.5,
 }
 
-TENX_LENIENT_RNA_DATA_KWARGS = {
-    "reader": functools.partial(
-        utils.sc_read_multi_files,
-        reader=lambda x: utils.sc_read_10x_h5_ft_type(x, "Gene Expression"),
-    ),
-    "transpose": False,  # We do not transpose because the h5 is already cell x gene
-    "gtf_file": HG38_GTF,
-    "autosomes_only": True,
-    "sort_by_pos": True,
-    "split_by_chrom": True,
-    "concat_outputs": True,
-    "selfsupervise": True,
-    "binarize": False,
-    "filt_cell_min_genes": 0,  # SNAREseq paper: minimum of 200 genes
-    "filt_cell_max_genes": 50000,  # SNAREseq paper: maximum of 2500 genes
-    "normalize": True,
-    "log_trans": True,
-    "clip": 0.5,  # Clip the bottom and top 0.5%
-    "y_mode": "size_norm",  # The output that we learn to predict
-    "calc_size_factors": True,
-    "return_sf": False,
-    "cluster_res": 1.5,
-}
-
 
 @functools.lru_cache(4)
 def sc_read_mtx(fname: str, dtype: str = "float32"):

--- a/babel/sc_data_loaders.py
+++ b/babel/sc_data_loaders.py
@@ -189,6 +189,30 @@ TENX_PBMC_RNA_DATA_KWARGS = {
     "cluster_res": 1.5,
 }
 
+TENX_LENIENT_RNA_DATA_KWARGS = {
+    "reader": functools.partial(
+        utils.sc_read_multi_files,
+        reader=lambda x: utils.sc_read_10x_h5_ft_type(x, "Gene Expression"),
+    ),
+    "transpose": False,  # We do not transpose because the h5 is already cell x gene
+    "gtf_file": HG38_GTF,
+    "autosomes_only": True,
+    "sort_by_pos": True,
+    "split_by_chrom": True,
+    "concat_outputs": True,
+    "selfsupervise": True,
+    "binarize": False,
+    "filt_cell_min_genes": 0,  # SNAREseq paper: minimum of 200 genes
+    "filt_cell_max_genes": 7000,  # SNAREseq paper: maximum of 2500 genes
+    "normalize": True,
+    "log_trans": True,
+    "clip": 0.5,  # Clip the bottom and top 0.5%
+    "y_mode": "size_norm",  # The output that we learn to predict
+    "calc_size_factors": True,
+    "return_sf": False,
+    "cluster_res": 1.5,
+}
+
 
 @functools.lru_cache(4)
 def sc_read_mtx(fname: str, dtype: str = "float32"):

--- a/babel/sc_data_loaders.py
+++ b/babel/sc_data_loaders.py
@@ -203,7 +203,7 @@ TENX_LENIENT_RNA_DATA_KWARGS = {
     "selfsupervise": True,
     "binarize": False,
     "filt_cell_min_genes": 0,  # SNAREseq paper: minimum of 200 genes
-    "filt_cell_max_genes": 7000,  # SNAREseq paper: maximum of 2500 genes
+    "filt_cell_max_genes": 50000,  # SNAREseq paper: maximum of 2500 genes
     "normalize": True,
     "log_trans": True,
     "clip": 0.5,  # Clip the bottom and top 0.5%

--- a/bin/predict_model.py
+++ b/bin/predict_model.py
@@ -333,11 +333,16 @@ def build_parser():
     parser.add_argument(
         "--skipatacsource", action="store_true", help="Skip analysis starting from ATAC"
     )
+    input_group.add_argument(
+        "--nofilter",
+        action="store_true",
+        help="Whether or not to perform filtering",
+    )
     return parser
 
 
 def load_rna_files_for_eval(
-    data, checkpoint: str, rna_genes_list_fname: str = "", no_filter: bool = False
+    data, checkpoint: str, rna_genes_list_fname: str = "", no_filter: bool = False, len
 ):
     """"""
     if not rna_genes_list_fname:
@@ -475,6 +480,7 @@ def main():
         args.data,
         args.checkpoint[0],
         args.genes,
+        no_filter = args.nofilter
     )
 
     if hasattr(sc_rna_full_dataset, "size_norm_counts"):

--- a/bin/predict_model.py
+++ b/bin/predict_model.py
@@ -333,7 +333,7 @@ def build_parser():
     parser.add_argument(
         "--skipatacsource", action="store_true", help="Skip analysis starting from ATAC"
     )
-    input_group.add_argument(
+    parser.add_argument(
         "--nofilter",
         action="store_true",
         help="Whether or not to perform filtering",

--- a/bin/predict_model.py
+++ b/bin/predict_model.py
@@ -342,7 +342,7 @@ def build_parser():
 
 
 def load_rna_files_for_eval(
-    data, checkpoint: str, rna_genes_list_fname: str = "", no_filter: bool = False, len
+    data, checkpoint: str, rna_genes_list_fname: str = "", no_filter: bool = False
 ):
     """"""
     if not rna_genes_list_fname:

--- a/bin/train_model.py
+++ b/bin/train_model.py
@@ -82,6 +82,11 @@ def build_parser():
         choices=["lung", "skin", "brain"],
         help="Load in the given SHAREseq datasets",
     )
+    input_group.add_argument(
+        "--lenienttenx",
+        action="store_true",
+        help="Data in 10x format, use custom data loading logic",
+    )
     parser.add_argument(
         "--linear",
         action="store_true",
@@ -229,6 +234,9 @@ def main():
                 batch_categories=args.shareseq,
             )
         rna_data_kwargs["raw_adata"] = shareseq_rna_adata
+    elif args.lenienttenx:
+        rna_data_kwargs = copy.copy(sc_data_loaders.TENX_LENIENT_RNA_DATA_KWARGS)
+        rna_data_kwargs["fname"] = args.data
     else:
         rna_data_kwargs = copy.copy(sc_data_loaders.TENX_PBMC_RNA_DATA_KWARGS)
         rna_data_kwargs["fname"] = args.data

--- a/bin/train_model.py
+++ b/bin/train_model.py
@@ -82,7 +82,7 @@ def build_parser():
         choices=["lung", "skin", "brain"],
         help="Load in the given SHAREseq datasets",
     )
-    input_group.add_argument(
+    parser.add_argument(
         "--nofilter",
         action="store_true",
         help="Whether or not to perform filtering",

--- a/bin/train_model.py
+++ b/bin/train_model.py
@@ -83,9 +83,9 @@ def build_parser():
         help="Load in the given SHAREseq datasets",
     )
     input_group.add_argument(
-        "--lenienttenx",
+        "--nofilter",
         action="store_true",
-        help="Data in 10x format, use custom data loading logic",
+        help="Whether or not to perform filtering",
     )
     parser.add_argument(
         "--linear",
@@ -234,12 +234,13 @@ def main():
                 batch_categories=args.shareseq,
             )
         rna_data_kwargs["raw_adata"] = shareseq_rna_adata
-    elif args.lenienttenx:
-        rna_data_kwargs = copy.copy(sc_data_loaders.TENX_LENIENT_RNA_DATA_KWARGS)
-        rna_data_kwargs["fname"] = args.data
     else:
         rna_data_kwargs = copy.copy(sc_data_loaders.TENX_PBMC_RNA_DATA_KWARGS)
         rna_data_kwargs["fname"] = args.data
+        if args.nofilter:
+            rna_data_kwargs = {
+                k: v for k, v in rna_data_kwargs.items() if not k.startswith("filt_")
+            }
     rna_data_kwargs["data_split_by_cluster_log"] = not args.linear
     rna_data_kwargs["data_split_by_cluster"] = args.clustermethod
 


### PR DESCRIPTION
This PR adds an argument which skips filtering. This allows training babel methods on small (synthetic) datasets. If filtering is not turned off, the dataset is completely empty after filtering.